### PR TITLE
Revise median to return value from 'review_count' key

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -703,7 +703,7 @@
     "        return median\n",
     "    else:\n",
     "        half = int((length - 1)/2)\n",
-    "        median = list_of_restaurants[half]\n",
+    "        median = list_of_restaurants[half]['review_count']\n",
     "        return median"
    ]
   },
@@ -744,21 +744,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Overview
In the `solution` branch, I noticed that the `else` in the `median_review_count()` function returned a `dictionary` rather than the value from the key `review_count`. 

#staff